### PR TITLE
Add an example for planpro-exporter with cli 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 .idea/
+
+*.ppxml

--- a/examples/planpro_generator.py
+++ b/examples/planpro_generator.py
@@ -1,0 +1,14 @@
+
+from planproexporter import Generator
+
+from cli_importer.cli import CLI
+
+if __name__ == '__main__':
+    _cli = CLI()
+    _cli.run()
+    generator = Generator()
+    generator.generate(_cli.topology,
+        author_name="Arne Boockmeyer",
+        organisation="HPI.OSM", filename="Test")
+    print("Generation completed")
+    print("Generator terminates.")

--- a/examples/planpro_generator.py
+++ b/examples/planpro_generator.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     _cli.run()
     generator = Generator()
     generator.generate(_cli.topology,
-        author_name="Arne Boockmeyer",
-        organisation="HPI.OSM", filename="Test")
+        author_name="Your Name",
+        organisation="Your Organization", filename="Export")
     print("Generation completed")
     print("Generator terminates.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,6 +29,24 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "cli-importer"
+version = "0.9"
+description = ""
+category = "dev"
+optional = false
+python-versions = "^3.10"
+develop = false
+
+[package.dependencies]
+yaramo = {git = "https://github.com/simulate-digital-rail/yaramo"}
+
+[package.source]
+type = "git"
+url = "https://github.com/simulate-digital-rail/cli-importer"
+reference = "HEAD"
+resolved_reference = "e333699246a298886d0b0d0c905d07ef08fa9ae7"
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -213,7 +231,7 @@ zipp = "3.8.1"
 type = "git"
 url = "https://github.com/simulate-digital-rail/orm-importer"
 reference = "HEAD"
-resolved_reference = "2e1bef9df785b9240f197498d4b66fc45809a98f"
+resolved_reference = "41b79b8443bf26ec819716d8eb323979f3b26c0a"
 
 [[package]]
 name = "overpy"
@@ -379,7 +397,7 @@ pyproj = "^3.4.1"
 type = "git"
 url = "https://github.com/simulate-digital-rail/yaramo"
 reference = "HEAD"
-resolved_reference = "a4474ac090c0497d695a86b14884013e598b8e4f"
+resolved_reference = "3aac7f7475430e337a772fb3052f7cd217e8a8c2"
 
 [[package]]
 name = "zipp"
@@ -396,7 +414,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "c8face8aa44328da37677cc5c462885232c402eca71ecd051adb3b62a022b3ec"
+content-hash = "264942b3e058c85d7e19f68a8f519d4f6e46f9d60ed00cecebffc7e54f83e476"
 
 [metadata.files]
 atomicwrites = [
@@ -410,6 +428,7 @@ certifi = [
     {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
     {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
 ]
+cli-importer = []
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -458,7 +477,6 @@ lxml = [
     {file = "lxml-4.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9cc34af337a97d470040f99ba4282f6e6bac88407d021688a5d585e44a23184"},
     {file = "lxml-4.9.2-cp310-cp310-win32.whl", hash = "sha256:d02a5399126a53492415d4906ab0ad0375a5456cc05c3fc0fc4ca11771745cda"},
     {file = "lxml-4.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:a38486985ca49cfa574a507e7a2215c0c780fd1778bb6290c21193b7211702ab"},
-    {file = "lxml-4.9.2-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:6943826a0374fb135bb11843594eda9ae150fba9d1d027d2464c713da7c09afe"},
     {file = "lxml-4.9.2-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c83203addf554215463b59f6399835201999b5e48019dc17f182ed5ad87205c9"},
     {file = "lxml-4.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:2a87fa548561d2f4643c99cd13131acb607ddabb70682dcf1dff5f71f781a4bf"},
     {file = "lxml-4.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:d6b430a9938a5a5d85fc107d852262ddcd48602c120e3dbb02137c83d212b380"},
@@ -469,6 +487,7 @@ lxml = [
     {file = "lxml-4.9.2-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca989b91cf3a3ba28930a9fc1e9aeafc2a395448641df1f387a2d394638943b0"},
     {file = "lxml-4.9.2-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:822068f85e12a6e292803e112ab876bc03ed1f03dddb80154c395f891ca6b31e"},
     {file = "lxml-4.9.2-cp35-cp35m-win32.whl", hash = "sha256:be7292c55101e22f2a3d4d8913944cbea71eea90792bf914add27454a13905df"},
+    {file = "lxml-4.9.2-cp35-cp35m-win_amd64.whl", hash = "sha256:998c7c41910666d2976928c38ea96a70d1aa43be6fe502f21a651e17483a43c5"},
     {file = "lxml-4.9.2-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:b26a29f0b7fc6f0897f043ca366142d2b609dc60756ee6e4e90b5f762c6adc53"},
     {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:ab323679b8b3030000f2be63e22cdeea5b47ee0abd2d6a1dc0c8103ddaa56cd7"},
     {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:689bb688a1db722485e4610a503e3e9210dcc20c520b45ac8f7533c837be76fe"},
@@ -478,6 +497,7 @@ lxml = [
     {file = "lxml-4.9.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:58bfa3aa19ca4c0f28c5dde0ff56c520fbac6f0daf4fac66ed4c8d2fb7f22e74"},
     {file = "lxml-4.9.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc718cd47b765e790eecb74d044cc8d37d58562f6c314ee9484df26276d36a38"},
     {file = "lxml-4.9.2-cp36-cp36m-win32.whl", hash = "sha256:d5bf6545cd27aaa8a13033ce56354ed9e25ab0e4ac3b5392b763d8d04b08e0c5"},
+    {file = "lxml-4.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:3ab9fa9d6dc2a7f29d7affdf3edebf6ece6fb28a6d80b14c3b2fb9d39b9322c3"},
     {file = "lxml-4.9.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:05ca3f6abf5cf78fe053da9b1166e062ade3fa5d4f92b4ed688127ea7d7b1d03"},
     {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:a5da296eb617d18e497bcf0a5c528f5d3b18dadb3619fbdadf4ed2356ef8d941"},
     {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:04876580c050a8c5341d706dd464ff04fd597095cc8c023252566a8826505726"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ orm-importer = {git = "https://github.com/simulate-digital-rail/orm-importer"}
 planpro-exporter = {git = "https://github.com/simulate-digital-rail/planpro-exporter"}
 
 
+[tool.poetry.group.dev.dependencies]
+cli-importer = {git = "https://github.com/simulate-digital-rail/cli-importer"}
+planpro-exporter = {git = "https://github.com/simulate-digital-rail/planpro-exporter"}
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This will add an _examples_ directory and also an existing example from the cli-importer repository using the planpro-exporter.